### PR TITLE
Support for headless/server builds

### DIFF
--- a/addons/gd-plug/plug.gd
+++ b/addons/gd-plug/plug.gd
@@ -704,7 +704,7 @@ class GitExecutable extends Reference:
 				cmd = cmd if read_stderr else "%s 2> nul" % cmd
 				logger.debug("Execute \"%s\"" % cmd)
 				exit = OS.execute("cmd", ["/C", cmd], blocking, output, read_stderr)
-			"X11", "OSX":
+			"X11", "OSX", "Server":
 				cmd if read_stderr else "%s 2>/dev/null" % cmd
 				logger.debug("Execute \"%s\"" % cmd)
 				exit = OS.execute("bash", ["-c", cmd], blocking, output, read_stderr)


### PR DESCRIPTION
Firstly, thank you for making and sharing this awesome plugin. I expect to be using it a lot!

Secondly, would you consider adding support for Godot headless and server builds?

This is especially useful for the running the plugin in headless CI/CD environments such as GitHub actions.

It should be as easy as adding "Server" alongside "X11" and "OSX" as headless/server builds are currently [only supported on Linux and macOS](https://docs.godotengine.org/en/3.3/getting_started/workflow/export/exporting_for_dedicated_servers.html#platform-support).

I tested this change using a basic plugin.gd file with server/headless builds locally on my Linux laptop and on GitHub actions using [this Godot headless Docker image](https://github.com/abarichello/godot-ci) ([results here](https://github.com/lihop/gd-plug/runs/2707770331?check_suite_focus=true#step:4:1)) , and everything seems to be working fine.