### PR TITLE
Move .plugged to addons/gd-plug/.plugged

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,6 @@ func _on_plugin_updated(plugin):
 
 ## Known Limitations
 
-- Godot always show errors from plugin repositories in `./plugged` even with `.gdignore` (See [#32](https://github.com/imjp94/gd-plug/issues/32))
 - Sometimes random .import files will be unable to remove, while the reason behind it still remains unknown.
   - Workaround: Read output for those .import files that failed to remove, and manually delete them.
 - `autoload` script references in project setting are not cleared as plugin uninstalled.

--- a/addons/gd-plug/plug.gd
+++ b/addons/gd-plug/plug.gd
@@ -594,10 +594,12 @@ func directory_copy_recursively(from, to, args={}):
 				dest_files += directory_copy_recursively(source, dest, args)
 			else:
 				for include_key in include:
-					if include_key in source:
+					var include_path = DEFAULT_PLUG_DIR + "/" + include_key
+					if include_path in source:
 						var is_excluded = false
 						for exclude_key in exclude:
-							if exclude_key in source:
+							var exclude_path = DEFAULT_PLUG_DIR + "/" + exclude_key
+							if exclude_path in source:
 								is_excluded = true
 								break
 						if not is_excluded:

--- a/addons/gd-plug/plug.gd
+++ b/addons/gd-plug/plug.gd
@@ -5,7 +5,7 @@ signal updated(plugin)
 
 const VERSION = "0.2.6"
 const DEFAULT_PLUGIN_URL = "https://git::@github.com/%s.git"
-const DEFAULT_PLUG_DIR = "res://.plugged"
+const DEFAULT_PLUG_DIR = "res://addons/gd-plug/.plugged"
 const DEFAULT_CONFIG_PATH = DEFAULT_PLUG_DIR + "/index.cfg"
 const DEFAULT_USER_PLUG_SCRIPT_PATH = "res://plug.gd"
 const DEFAULT_BASE_PLUG_SCRIPT_PATH = "res://addons/gd-plug/plug.gd"


### PR DESCRIPTION
Moving the dir here stops gdscript warnings from triggering on addon code. The Godot team have indicated that they will only support disabling warnings in this directory as it is the only place third party code should be placed.

This change addresses #32, following the discussion there and at https://github.com/godotengine/godot/pull/93889