### PR TITLE
Fix post update function calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Post update hook can be connected in 3 ways:
 - Connect to `update` signal
   - `connect("updated", self, "post_update")`
 - Overwriting `_on_updated` function
-  - `func _on_update(plugin)`
+  - `func _on_updated(plugin)`
 
 Post update hook always returned with one argument - dictionary that store information about the plugin
 

--- a/addons/gd-plug/plug.gd
+++ b/addons/gd-plug/plug.gd
@@ -527,12 +527,15 @@ func install(plugin):
 	logger.info("Installed %d file%s for %s" % [dest_files.size(), "s" if dest_files.size() > 1 else "", plugin.name])
 	if plugin.name != "gd-plug":
 		set_installed_plugin(plugin)
+	
+	logger.debug("Execute \"_on_updated\" function for %s" % plugin.name)
+	_on_updated(plugin.duplicate())
 	if plugin.on_updated:
 		if has_method(plugin.on_updated):
-			logger.info("Execute post-update function for %s" % plugin.name)
-			_on_updated(plugin)
+			logger.debug("Execute post-update function \"%s\" for %s" % [plugin.on_updated, plugin.name])
 			call(plugin.on_updated, plugin.duplicate())
-			emit_signal("updated", plugin)
+	logger.debug("Emit \"updated\" signal for %s" % plugin.name)
+	emit_signal("updated", plugin.duplicate())
 	return OK
 
 func uninstall(plugin):


### PR DESCRIPTION
According to [Post Update Hook](https://github.com/imjp94/gd-plug?tab=readme-ov-file#post-update-hook) section those three functions should run independently, but are currently depending on the `on_updated` key being filled